### PR TITLE
Removing research requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,6 @@ jobs:
 
       - name: Setup steamcmd
         uses: CyberAndrii/setup-steamcmd@v1
-        # sudo add-apt-repository multiverse && sudo apt update -y && sudo apt install -y steamcmd
 
       # - name: Publish to Steam Workshop
       #   run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,6 +223,7 @@ jobs:
 
       - name: Setup steamcmd
         uses: CyberAndrii/setup-steamcmd@v1
+        # sudo add-apt-repository multiverse && sudo apt update -y && sudo apt install -y steamcmd
 
       # - name: Publish to Steam Workshop
       #   run: |

--- a/1.6/Defs/ElectricityMeter.xml
+++ b/1.6/Defs/ElectricityMeter.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <ResearchProjectDef>
-    <!-- Name -->
-    <defName>ElectricityMeterResearch</defName>
-    <label>Electricity meter</label>
-    <description>Allows construction of a power meter that can monitor and display electricity usage
-      on a power network.</description>
-
-    <!-- Graphic -->
-    <researchViewX>7.00</researchViewX>
-    <researchViewY>0.30</researchViewY>
-
-    <!-- Requirements -->
-    <techLevel>Industrial</techLevel>
-    <prerequisites>
-      <li>Electricity</li>
-    </prerequisites>
-    <baseCost>400</baseCost>
-  </ResearchProjectDef>
-
   <ThingDef ParentName="BuildingBase">
     <!-- Name -->
     <defName>ElectricityMeter</defName>
@@ -62,7 +43,7 @@
 
     <!-- Game -->
     <researchPrerequisites>
-      <li>ElectricityMeterResearch</li>
+      <li>Electricity</li>
     </researchPrerequisites>
 
     <!-- Logic -->


### PR DESCRIPTION
Based on lots of feedback to remove the research requirement, I'm removing the research requirement.

<img width="631" height="420" alt="{D184F417-191D-4261-B7C9-43C4E18E1922}" src="https://github.com/user-attachments/assets/59dd9607-7061-4cca-a5bb-61f7b21c18d7" />

As [DeathKnight ](https://steamcommunity.com/id/NotsoFatDeath) suggested, I can still require the base electricity research.